### PR TITLE
Credits withdraw

### DIFF
--- a/src/crud.py
+++ b/src/crud.py
@@ -156,6 +156,7 @@ def update_credits(db: Session, credit_update: schemas.CreditUpdate):
     except NoResultFound as e:
         raise CreditNotFound() from e
 
+
 def update_credits_from_contract_address(db: Session, amount: int, address: str):
     try:
         db_contract: Optional[models.Credit] = db.query(models.Contract).filter(models.Contract.address == address).one_or_none()
@@ -166,3 +167,21 @@ def update_credits_from_contract_address(db: Session, amount: int, address: str)
         return db_contract.credit
     except NoResultFound as e:
         raise CreditNotFound() from e
+
+
+def get_credits_from_contract_address(db: Session, contract_address: str):
+    try:
+        db_contract = db.query(models.Contract).filter(
+            models.Contract.address == contract_address
+        ).one_or_none()
+        if db_contract is None:
+            raise ContractNotFound()
+        print(db_contract)
+        db_credit = db.query(models.Credit).filter(
+            models.Credit.id == db_contract.credit_id
+        ).one_or_none()
+        if db_credit is None:
+            raise CreditNotFound()
+        return db_credit
+    except NoResultFound as e:
+        raise ContractNotFound() from e

--- a/src/crud.py
+++ b/src/crud.py
@@ -169,6 +169,16 @@ def update_credits_from_contract_address(db: Session, amount: int, address: str)
         raise CreditNotFound() from e
 
 
+def get_credits(db: Session, uuid: UUID4):
+    """
+    Return a models.Credit or raise UserNotFound exception
+    """
+    db_credit = db.query(models.Credit).get(uuid)
+    if (db_credit is None):
+        raise CreditNotFound()
+    return db_credit
+
+
 def get_credits_from_contract_address(db: Session, contract_address: str):
     try:
         db_contract = db.query(models.Contract).filter(

--- a/src/routes.py
+++ b/src/routes.py
@@ -94,6 +94,7 @@ async def withdraw_credits(
         )
 
     owner_address = credits.owner.address
+    user = crud.get_user_by_address(db, owner_address)
     public_key = tezos.get_public_key(owner_address)
     is_valid = tezos.check_signature(withdraw.to_micheline_pair(),
                                      withdraw.micheline_signature,
@@ -110,6 +111,7 @@ async def withdraw_credits(
         credit_update = schemas.CreditUpdate(id=withdraw.id,
                                              amount=-withdraw.amount,
                                              # FIXME I guess
+                                             owner_id=str(user.id),
                                              operation_hash="")
         crud.update_credits(db, credit_update)
     return result

--- a/src/schemas.py
+++ b/src/schemas.py
@@ -44,6 +44,7 @@ class CreditUpdate(BaseModel):
     id: UUID4
     amount: int
     operation_hash: str
+    owner_id: str
 
 
 class CreditWithdraw(BaseModel):

--- a/src/schemas.py
+++ b/src/schemas.py
@@ -39,8 +39,29 @@ class Credit(BaseModel):
 class CreditCreation(BaseModel):
   owner_id: UUID4
 
-class CreditUpdate(Credit):
+
+class CreditUpdate(BaseModel):
+    id: UUID4
+    amount: int
     operation_hash: str
+
+
+class CreditWithdraw(BaseModel):
+    id: UUID4
+    amount: int
+    micheline_signature: str
+
+    def to_micheline_pair(self):
+        return [
+            {"string": self.id},
+            {"int": self.amount}
+        ]
+
+
+class WithdrawResponse(BaseModel):
+    id: UUID4
+    operation_hash: str
+
 
 # Contracts
 class ContractBase(BaseModel):

--- a/src/tezos.py
+++ b/src/tezos.py
@@ -73,6 +73,21 @@ async def confirm_amount(tx_hash, payer, amount: Union[int,str]):
     )
 
 
+def simulate_transaction(operations):
+    op = ptz.bulk(
+        *[
+            ptz.transaction(
+                source=ptz.key.public_key_hash(),
+                parameters=operation["parameters"],
+                destination=operation["destination"],
+                amount=0,
+            )
+            for operation in operations
+        ]  # type: ignore
+    )
+    return op.autofill()
+
+
 class TezosManager:
     def __init__(self, ptz):
         self.ops_queue = OrderedDict()


### PR DESCRIPTION
This PR
- reorganizes and cleans the code for routes and tezos modules. In particular, `PUT /credits` is renamed to `PUT /deposit`
- adds a few exception catchers to prevent some HTTP 500 errors;
- fixes a bug: when no tez were deposited, we now actually refuse to pay for operations.
- implements a `/withdraw` endpoint which checks that the credits exist, that the caller is not trying to withdraw more than the total amount, that the **Micheline pair corresponding to the withdraw** was correctly signed. If then queues the withdraw operation, and, if this operation succeeds, updates the credit in the database.

I chose to sign a Micheline pair instead of a JSON object to make sure it works with all wallets.

This PR requires a full review and local tests (deposits, withdraw, adding a contract, etc.). Before merging, the UI needs to be adapted as well (/deposit entrypoint, /withdraw entrypoint). The code can be improved at some point, feel free to open the discussion about anything. Suggestions are welcome.