### PR TITLE
Withdraw counter

### DIFF
--- a/src/crud.py
+++ b/src/crud.py
@@ -13,7 +13,7 @@ def get_user(db: Session, uuid: UUID4):
     Return a models.User or raise UserNotFound exception
     """
     db_user: Optional[models.User] = db.query(models.User).get(uuid)
-    if (db_user is None):
+    if db_user is None:
         raise UserNotFound()
     return db_user
 
@@ -122,6 +122,18 @@ def get_user_credits(db: Session, user_id: str):
     """
     db_credits = db.query(models.Credit).filter(models.Credit.owner_id == user_id).all()
     return db_credits
+
+
+def update_user_withdraw_counter(db: Session,
+                                 user_id: str,
+                                 withdraw_counter: int):
+    try:
+        db.query(models.User).filter(
+            models.User.id == user_id
+        ).update({"withdraw_counter": withdraw_counter})
+        db.commit()
+    except NoResultFound as e:
+        raise UserNotFound from e
 
 
 def create_credits(db: Session, credit: schemas.CreditCreation):

--- a/src/models.py
+++ b/src/models.py
@@ -11,6 +11,7 @@ class User(Base):
   id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
   name = Column(String)
   address = Column(String, unique=True)
+  withdraw_counter = Column(Integer, default=0)
 
   contracts = relationship("Contract", back_populates="owner")
   credits = relationship("Credit", back_populates="owner")

--- a/src/routes.py
+++ b/src/routes.py
@@ -52,7 +52,7 @@ async def update_credits(
     credits: schemas.CreditUpdate, db: Session = Depends(database.get_db)
 ):
     try:
-        payer_address = crud.get_user(db, credits.owner_id).address
+        payer_address = crud.get_credits(db, credits.id).owner.address
         op_hash = credits.operation_hash
         amount = credits.amount
         is_confirmed = await tezos.confirm_deposit(op_hash,
@@ -73,6 +73,11 @@ async def update_credits(
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Credit not found.",
+        )
+    except tezos.OperationNotFound:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Could not find the operation.",
         )
 
 

--- a/src/schemas.py
+++ b/src/schemas.py
@@ -50,11 +50,13 @@ class CreditUpdate(BaseModel):
 class CreditWithdraw(BaseModel):
     id: UUID4
     amount: int
+    withdraw_counter: int
     micheline_signature: str
 
     def to_micheline_pair(self):
         return [
             {"string": self.id},
+            {"int": self.withdraw_counter},
             {"int": self.amount}
         ]
 
@@ -62,6 +64,10 @@ class CreditWithdraw(BaseModel):
 class WithdrawResponse(BaseModel):
     id: UUID4
     operation_hash: str
+
+
+class WithdrawCounter(BaseModel):
+    counter: int
 
 
 # Contracts

--- a/src/tezos.py
+++ b/src/tezos.py
@@ -4,7 +4,7 @@ from typing import Union
 
 from src import database
 # from .pytezos import ptz, pytezos
-from . import crud
+from . import crud, schemas
 from pytezos.rpc.errors import MichelsonError
 from pytezos.michelson.types import MichelsonType
 import pytezos
@@ -92,6 +92,15 @@ async def confirm_deposit(tx_hash, payer, amount: Union[int, str]):
         and op["destination"] == receiver
         and int(op["amount"]) == int(amount)
     )
+
+
+async def confirm_withdraw(tx_hash, db, user_id, withdraw):
+    await find_transaction(tx_hash)
+    credit_update = schemas.CreditUpdate(id=withdraw.id,
+                                         amount=-withdraw.amount,
+                                         owner_id=user_id, operation_hash="")
+    crud.update_credits(db, credit_update)
+    crud.update_user_withdraw_counter(db, user_id, withdraw.withdraw_counter+1)
 
 
 def simulate_transaction(operations):

--- a/src/tezos.py
+++ b/src/tezos.py
@@ -23,6 +23,10 @@ print(f"INFO: API address is {ptz.key.public_key_hash()}")
 constants = ptz.shell.block.context.constants()
 
 
+class OperationNotFound(Exception):
+    pass
+
+
 async def find_transaction(tx_hash):
     block_time = int(constants["minimal_block_delay"])
     nb_try = 0
@@ -34,7 +38,7 @@ async def find_transaction(tx_hash):
             nb_try += 1
             await asyncio.sleep(block_time)
     else:
-        raise Exception(f"Couldn't find operation {tx_hash}")
+        raise OperationNotFound(tx_hash)
 
     return op_result
 

--- a/src/tezos.py
+++ b/src/tezos.py
@@ -121,6 +121,7 @@ def check_signature(pair_data, signature, public_key):
         "prim": 'pair',
         "args": [
             {"prim": 'string'},
+            {"prim": "int"},
             {"prim": 'mutez'}
         ]
     }


### PR DESCRIPTION
We now use a nonce to protect from replay attacks. I don't think that was such a big issue, but oh well.

This requires a new change in the front-end:
- you may use the GET `/withdraw_counter/{user_address}` endpoint
- you need to sign it as well.