### PR TITLE
API Routes update

### DIFF
--- a/src/crud.py
+++ b/src/crud.py
@@ -53,7 +53,7 @@ def get_contracts_by_credit(db: Session, credit_id: str):
         models.Contract.credit_id == credit_id).all()
 
 
-def get_contract(db: Session, address: str):
+def get_contract_by_address(db: Session, address: str):
     """
     Return a models.Contract or raise ContractNotFound exception
     """
@@ -65,21 +65,37 @@ def get_contract(db: Session, address: str):
         raise ContractNotFound() from e
 
 
-def get_entrypoints(db: Session,
-                    contract_address: str) -> List[models.Entrypoint]:
+def get_contract(db: Session, contract_id: str):
+    """
+    Return a models.Contract or raise ContractNotFound exception
+    """
+    try:
+        return db.query(models.Contract).get(contract_id)
+    except NoResultFound as e:
+        raise ContractNotFound() from e
+
+
+def get_entrypoints(
+    db: Session,
+    contract_address_or_id: str
+) -> List[models.Entrypoint]:
     """
     Return a list of models.Contract or raise ContractNotFound exception
     """
-    contract = get_contract(db, contract_address)
+    if contract_address_or_id.startswith("KT"):
+        contract = get_contract_by_address(db, contract_address_or_id)
+    else:
+        contract = get_contract(db, contract_address_or_id)
     return contract.entrypoints
 
 
-def get_entrypoint(db: Session, contract_address: str,
+def get_entrypoint(db: Session,
+                   contract_address_or_id: str,
                    name: str) -> Optional[models.Entrypoint]:
     """
     Return a models.Entrypoint or raise EntrypointNotFound exception
     """
-    entrypoints = get_entrypoints(db, contract_address)
+    entrypoints = get_entrypoints(db, contract_address_or_id)
     entrypoint = [e for e in entrypoints if e.name == name]  # type: ignore
     if len(entrypoint) == 0:
         raise EntrypointNotFound()

--- a/src/routes.py
+++ b/src/routes.py
@@ -150,22 +150,6 @@ async def get_user(user_address: str, db: Session = Depends(database.get_db)):
         )
 
 
-@router.get("/withdraw_counter/{user_address}",
-            response_model=schemas.WithdrawCounter)
-async def get_withdraw_counter(user_address: str,
-                               db: Session = Depends(database.get_db)):
-    try:
-        counter = crud.get_user_by_address(db, user_address).withdraw_counter
-        if counter is None:
-            counter = 0
-        return schemas.WithdrawCounter(counter=counter)
-    except UserNotFound:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"User not found.",
-        )
-
-
 @router.get("/credits/{user_id}", response_model=list[schemas.Credit])
 async def credits_for_user(
     user_id: str, db: Session = Depends(database.get_db)

--- a/src/schemas.py
+++ b/src/schemas.py
@@ -88,8 +88,15 @@ class ContractCreation(ContractBase):
   credit_id: UUID4
 
 # Operations
-# TODO: right now the sender isn't checked, as we use permits anyway
-class CallData(BaseModel):
-    sender: str
+class UnsignedCall(BaseModel):
+    """Data sent when posting an operation. The sender is mandatory."""
+    sender_address: str
     operations: list[dict[str, Any]]
 
+
+class SignedCall(BaseModel):
+    """Data sent when posting an operation. The signature"""
+    sender_key: str
+    operations: list[dict[str, Any]]
+    signature: str
+    micheline_type: Any


### PR DESCRIPTION
* Remove the withdraw_counter, now returned in the user schema
* Easier interface, allowing addresses or UUIDs when possible
* Use the right HTTP return code
* Tentative POST /signed_operations/: not satisfying as it does not include the contract name (hence the signature could be misused) but better than nothing.