### PR TITLE
[WIP] Prototype for a remote API validation

### DIFF
--- a/api-usage.ipynb
+++ b/api-usage.ipynb
@@ -71,9 +71,9 @@
    "outputs": [],
    "source": [
     "r = requests.post(\n",
-    "    f\"{gas_station_api}/users\",\n",
+    "    f\"{gas_station_api}/sponsors\",\n",
     "    json = {\n",
-    "        \"address\": alice.public_key_hash(),\n",
+    "        \"tezos_address\": alice.public_key_hash(),\n",
     "        \"name\": \"alice\"\n",
     "    }\n",
     ")"
@@ -96,7 +96,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "r = requests.get(f\"{gas_station_api}/users/{alice.public_key_hash()}\")"
+    "r = requests.get(f\"{gas_station_api}/sponsors/{alice.public_key_hash()}\")"
    ]
   },
   {
@@ -108,8 +108,8 @@
     {
      "data": {
       "text/plain": [
-       "{'address': 'tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb',\n",
-       " 'id': '06d44229-4b75-4df5-9bac-df3b53285859',\n",
+       "{'tezos_address': 'tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb',\n",
+       " 'id': '2a5e9326-e725-4e60-a8cb-816bad6a4f7b',\n",
        " 'name': 'alice',\n",
        " 'withdraw_counter': 0}"
       ]
@@ -133,9 +133,9 @@
     {
      "data": {
       "text/plain": [
-       "{'id': '958caaa8-ed25-4c26-a062-42bd78182399',\n",
+       "{'id': '0cfb5c6d-9655-46c2-bddc-42b772b05367',\n",
        " 'amount': 0,\n",
-       " 'owner_id': '06d44229-4b75-4df5-9bac-df3b53285859'}"
+       " 'owner_id': '2a5e9326-e725-4e60-a8cb-816bad6a4f7b'}"
       ]
      },
      "execution_count": 9,
@@ -144,7 +144,7 @@
     }
    ],
    "source": [
-    "r = requests.get(f\"{gas_station_api}/credits/{alice_user['address']}\")\n",
+    "r = requests.get(f\"{gas_station_api}/credits/{alice_user['tezos_address']}\")\n",
     "credits = r.json()[0]\n",
     "assert r.status_code == 200\n",
     "credits"
@@ -248,20 +248,9 @@
    "execution_count": 16,
    "id": "bcba5181",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "200"
-      ]
-     },
-     "execution_count": 16,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "r.status_code"
+    "assert r.status_code == 200"
    ]
   },
   {
@@ -273,9 +262,9 @@
     {
      "data": {
       "text/plain": [
-       "[{'id': '958caaa8-ed25-4c26-a062-42bd78182399',\n",
+       "[{'id': '0cfb5c6d-9655-46c2-bddc-42b772b05367',\n",
        "  'amount': 1000000,\n",
-       "  'owner_id': '06d44229-4b75-4df5-9bac-df3b53285859'}]"
+       "  'owner_id': '2a5e9326-e725-4e60-a8cb-816bad6a4f7b'}]"
       ]
      },
      "execution_count": 17,
@@ -310,7 +299,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "14\n"
+      "25\n"
      ]
     }
    ],
@@ -374,7 +363,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 22,
    "id": "8ff9a023",
    "metadata": {},
    "outputs": [
@@ -382,7 +371,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "15\n"
+      "25\n"
      ]
     }
    ],
@@ -395,7 +384,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 23,
    "id": "5508e9bc",
    "metadata": {},
    "outputs": [],
@@ -408,7 +397,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 24,
    "id": "0cbecd7f",
    "metadata": {},
    "outputs": [],
@@ -427,7 +416,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 25,
    "id": "33cbdddf",
    "metadata": {},
    "outputs": [
@@ -437,7 +426,7 @@
        "<Response [200]>"
       ]
      },
-     "execution_count": 27,
+     "execution_count": 25,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -456,7 +445,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 26,
    "id": "202834f6",
    "metadata": {},
    "outputs": [
@@ -466,7 +455,7 @@
        "200"
       ]
      },
-     "execution_count": 29,
+     "execution_count": 26,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -493,7 +482,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 27,
    "id": "b34ffa8d",
    "metadata": {},
    "outputs": [
@@ -503,7 +492,7 @@
        "400"
       ]
      },
-     "execution_count": 30,
+     "execution_count": 27,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -530,7 +519,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 28,
    "id": "166eb0a0",
    "metadata": {},
    "outputs": [
@@ -540,7 +529,7 @@
        "200"
       ]
      },
-     "execution_count": 31,
+     "execution_count": 28,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -559,7 +548,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 29,
    "id": "9daae29e",
    "metadata": {},
    "outputs": [
@@ -567,17 +556,17 @@
      "data": {
       "text/plain": [
        "[{'type': 'MAX_CALLS_PER_SPONSEE',\n",
-       "  'vault_id': '958caaa8-ed25-4c26-a062-42bd78182399',\n",
-       "  'created_at': '2024-03-12T18:00:11.362107+00:00',\n",
-       "  'id': '928a842a-68da-48c6-b9fa-cccd71ccacb1',\n",
-       "  'contract_id': '4b0a9fdf-d36a-4ce8-af4c-1facc8ae1371',\n",
+       "  'vault_id': '0cfb5c6d-9655-46c2-bddc-42b772b05367',\n",
+       "  'created_at': '2024-03-15T10:55:20.172575+00:00',\n",
+       "  'is_active': True,\n",
+       "  'id': 'c86187e1-f184-4a2d-8dda-094cc581820f',\n",
+       "  'contract_id': 'a7f3f5ee-a790-4784-b57b-b9e486d88838',\n",
        "  'entrypoint_id': None,\n",
        "  'max': 1,\n",
-       "  'current': 2,\n",
-       "  'is_active': True}]"
+       "  'current': 2}]"
       ]
      },
-     "execution_count": 32,
+     "execution_count": 29,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -587,14 +576,6 @@
     "    f\"{gas_station_api}/condition/{credits['id']}\"\n",
     ").json()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "01e26527",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/examples/main.py
+++ b/examples/main.py
@@ -1,0 +1,95 @@
+import asyncio
+from typing import Any, Optional
+import os
+
+from fastapi import FastAPI, APIRouter, HTTPException, Request, status
+from fastapi.responses import JSONResponse
+from fastapi.encoders import jsonable_encoder
+from pydantic import BaseModel
+
+from Crypto.PublicKey import RSA
+import jwt
+
+api_url = os.getenv("GAS_STATION_URL")
+router = APIRouter()
+
+
+class Operation(BaseModel):
+    """Data sent when posting an operation. The sender is mandatory."""
+
+    sender_address: str
+    operations: list[dict[str, Any]]
+
+
+class Receipt(BaseModel):
+    """Signature of an operation to be posted on-chain."""
+    gas_station_action: Optional[str]
+    signature: str
+
+
+try:
+    skey = "".join(open("./private.pem").readlines())
+    pkey = "".join(open("./public.pem").readlines())
+except FileNotFoundError:
+    mykey = RSA.generate(1024)
+    skey = mykey.export_key()
+    pkey = mykey.public_key().export_key()
+    with open("./private.pem", "w") as f:
+        f.write(skey)
+    with open("./public.pem", "w") as f:
+        f.write(pkey)
+
+
+# We will assume this API runs in only one thread, and ignore race conditions
+# for this example.
+# Shared database of senders, to limit the number of sponsored operations
+# per user. This could be implemented as a condition directly in the gas
+# station as well.
+seen_senders = dict()
+
+
+def validate(sender):
+    seen = seen_senders.get(sender, 0)
+    if seen > 1:
+        return False
+    else:
+        seen_senders[sender] = seen + 1
+        return True
+
+
+@router.post("/operation", response_model=Receipt)
+async def sign_operation(request: Request):
+    raw_operation = await request.json()
+    try:
+        operation = Operation.parse_obj(raw_operation)
+    except:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"Could not parse operation",
+        )
+
+    if validate(operation.sender_address):
+        signature = jwt.encode(
+            raw_operation, key=skey, algorithm="RS256"
+        )
+        return Receipt(
+            gas_station_action="post_operation",
+            signature=signature
+        )
+    else:
+        raise JSONResponse(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            content=jsonable_encoder(
+                {
+                    "detail": "Invalid call",
+                    "body": "User has already used its quota",
+                    "custom msg": {"Your error message"}
+                }
+            )
+        )
+
+
+app = FastAPI()
+app.include_router(router)
+
+loop = asyncio.get_event_loop()

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ pytezos
 python-multipart
 uvicorn[standard]
 fastapi
-python-jose[cryptography]
+pyjwt[cryptography]
 python-dotenv
 pydantic
 sqlalchemy

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ pydantic
 sqlalchemy
 psycopg2
 alembic
+aiohttp

--- a/sql/init_db.sql
+++ b/sql/init_db.sql
@@ -1,4 +1,4 @@
-INSERT INTO users("id", "name", "address", "withdraw_counter")
+INSERT INTO sponsors("id", "name", "address", "withdraw_counter")
         VALUES
         ('164b18e2-205b-47fa-8fa5-e9961b3a8437', 'Alfred', 'tz1VLKbNYhmfyQSZzsdLWrbtVbyjsRf9qEjN', 0),
         ('b8c23360-9a81-4450-93d8-ea32a2d7467e', 'Quentin', 'tz1YdFws2E182i25ezpHvEvcn4vh74XcMDFi', 0);

--- a/src/crud.py
+++ b/src/crud.py
@@ -31,7 +31,12 @@ def get_sponsor_by_address(db: Session, tezos_address: str):
     Return a models.Sponsor or raise SponsorNotFound exception
     """
     try:
-        return db.query(models.Sponsor).filter(models.Sponsor.tezos_address == tezos_address).one()
+        db_sponsor = (
+            db.query(models.Sponsor)
+            .filter(models.Sponsor.tezos_address == tezos_address)
+            .one()
+        )
+        return db_sponsor
     except NoResultFound as e:
         raise SponsorNotFound() from e
 
@@ -125,6 +130,25 @@ def create_contract(db: Session, contract: schemas.ContractCreation):
         db.add_all(db_entrypoints)
         db.commit()
         return db_contract
+
+
+def update_sponsor_api(db: Session, api_update: schemas.SponsorAPIUpdate):
+    db_sponsor_api = models.SponsorAPI(**{
+        "url": api_update.api_url,
+        "public_key": api_update.public_key
+    })
+    db.add(db_sponsor_api)
+    db.commit()
+    sponsor = (
+        db
+        .query(models.Sponsor)
+        .filter(models.Sponsor.id == api_update.sponsor_id)
+        .update({
+            "api_id": db_sponsor_api.id
+        })
+    )
+    db.commit()
+    return sponsor
 
 
 def update_entrypoints(db: Session, entrypoints: list[schemas.EntrypointUpdate]):

--- a/src/crud.py
+++ b/src/crud.py
@@ -10,51 +10,51 @@ from .utils import (
     ContractNotFound,
     CreditNotFound,
     EntrypointNotFound,
-    UserNotFound,
+    SponsorNotFound,
 )
 from . import models, schemas
 from sqlalchemy.exc import NoResultFound
 
 
-def get_user(db: Session, uuid: UUID4):
+def get_sponsor(db: Session, uuid: UUID4):
     """
-    Return a models.User or raise UserNotFound exception
+    Return a models.Sponsor or raise SponsorNotFound exception
     """
-    db_user: Optional[models.User] = db.query(models.User).get(uuid)
-    if db_user is None:
-        raise UserNotFound()
-    return db_user
+    db_sponsor: Optional[models.Sponsor] = db.query(models.Sponsor).get(uuid)
+    if db_sponsor is None:
+        raise SponsorNotFound()
+    return db_sponsor
 
 
-def get_user_by_address(db: Session, address: str):
+def get_sponsor_by_address(db: Session, tezos_address: str):
     """
-    Return a models.User or raise UserNotFound exception
+    Return a models.Sponsor or raise SponsorNotFound exception
     """
     try:
-        return db.query(models.User).filter(models.User.address == address).one()
+        return db.query(models.Sponsor).filter(models.Sponsor.tezos_address == tezos_address).one()
     except NoResultFound as e:
-        raise UserNotFound() from e
+        raise SponsorNotFound() from e
 
 
-def create_user(db: Session, user: schemas.UserCreation):
-    db_user = models.User(**user.model_dump())
-    db.add(db_user)
+def create_sponsor(db: Session, sponsor: schemas.SponsorCreation):
+    db_sponsor = models.Sponsor(**sponsor.model_dump())
+    db.add(db_sponsor)
     db.commit()
-    db.refresh(db_user)
-    return db_user
+    db.refresh(db_sponsor)
+    return db_sponsor
 
 
-def get_contracts_by_user(db: Session, user_address: str):
+def get_contracts_by_sponsor(db: Session, sponsor_address: str):
     """
-    Return a list of models.Contracts or raise UserNotFound exception
+    Return a list of models.Contracts or raise SponsorNotFound exception
     """
-    user = get_user_by_address(db, user_address)
-    return user.contracts
+    sponsor = get_sponsor_by_address(db, sponsor_address)
+    return sponsor.contracts
 
 
 def get_contracts_by_credit(db: Session, credit_id: str):
     """
-    Return a list of models.Contracts or raise UserNotFound exception
+    Return a list of models.Contracts or raise SponsorNotFound exception
     """
     return (
         db.query(models.Contract).filter(models.Contract.credit_id == credit_id).all()
@@ -141,28 +141,28 @@ def update_entrypoints(db: Session, entrypoints: list[schemas.EntrypointUpdate])
     )
 
 
-def get_user_credits(db: Session, user_id: str):
+def get_sponsor_credits(db: Session, sponsor_id: str):
     """
-    Get credits from a user.
+    Get credits from a sponsor.
     """
-    db_credits = db.query(models.Credit).filter(models.Credit.owner_id == user_id).all()
+    db_credits = db.query(models.Credit).filter(models.Credit.owner_id == sponsor_id).all()
     return db_credits
 
 
-def update_user_withdraw_counter(db: Session, user_id: str, withdraw_counter: int):
+def update_sponsor_withdraw_counter(db: Session, sponsor_id: str, withdraw_counter: int):
     try:
-        db_user: Optional[models.User] = db.query(models.User).get(user_id)
-        if db_user is None:
-            raise UserNotFound()
+        db_sponsor: Optional[models.Sponsor] = db.query(models.Sponsor).get(sponsor_id)
+        if db_sponsor is None:
+            raise SponsorNotFound()
 
-        db.query(models.User).filter(models.User.id == user_id).update(
+        db.query(models.Sponsor).filter(models.Sponsor.id == sponsor_id).update(
             {"withdraw_counter": withdraw_counter}
         )
 
         db.commit()
-        return db_user.withdraw_counter
+        return db_sponsor.withdraw_counter
     except NoResultFound as e:
-        raise UserNotFound from e
+        raise SponsorNotFound from e
 
 
 def create_credits(db: Session, credit: schemas.CreditCreation):
@@ -170,15 +170,15 @@ def create_credits(db: Session, credit: schemas.CreditCreation):
     Creates credits for a given owner and returns a models.Credit.
     """
     try:
-        # Check if the user exists
-        _ = db.query(models.User).get(credit.owner_id)
+        # Check if the sponsor exists
+        _ = db.query(models.Sponsor).get(credit.owner_id)
         credit = models.Credit(**credit.model_dump())
         db.add(credit)
         db.commit()
         # db.refresh(credit)
         return credit
     except NoResultFound as e:
-        raise UserNotFound() from e
+        raise SponsorNotFound() from e
 
 
 def update_credits(db: Session, credit_update: schemas.CreditUpdate):
@@ -222,7 +222,7 @@ def update_credits_from_contract_address(db: Session, amount: int, address: str)
 
 def get_credits(db: Session, uuid: UUID4):
     """
-    Return a models.Credit or raise UserNotFound exception
+    Return a models.Credit or raise SponsorNotFound exception
     """
     db_credit = db.query(models.Credit).get(uuid)
     if db_credit is None:

--- a/src/models.py
+++ b/src/models.py
@@ -9,6 +9,7 @@ from sqlalchemy import (
     String,
 )
 from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
 from sqlalchemy.dialects.postgresql import UUID
 import uuid
 
@@ -144,7 +145,7 @@ class Operation(Base):
     entrypoint_id = Column(UUID(as_uuid=True), ForeignKey("entrypoints.id"))
     hash = Column(String)
     status = Column(String)  # TODO Enum
-    created_at = Column(DateTime(timezone=True), default=datetime.datetime.utcnow())
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
 
     contract = relationship("Contract", back_populates="operations")
     entrypoint = relationship("Entrypoint", back_populates="operations")
@@ -182,7 +183,7 @@ class Condition(Base):
     max = Column(Integer, nullable=False)
     current = Column(Integer, nullable=False)
     created_at = Column(
-        DateTime(timezone=True), default=datetime.datetime.utcnow(), nullable=False
+        DateTime(timezone=True), server_default=func.now(), nullable=False
     )
     is_active = Column(Boolean, nullable=False)
     contract = relationship("Contract", back_populates="conditions")

--- a/src/models.py
+++ b/src/models.py
@@ -26,6 +26,19 @@ import datetime
 #   receipt to the gas station (which then posts the operations itself)
 # If the sponsor API returns the operation to the GS, then the sponsor must
 # have deposited credits.
+class SponsorAPI(Base):
+    __tablename__ = "sponsor_apis"
+
+    def __repr__(self):
+        return "API(id='{}', url='{}')".format(
+            self.id, self.url
+        )
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    url = Column(String, unique=True)
+    public_key = Column(String, nullable=False)
+
+
 class Sponsor(Base):
     __tablename__ = "sponsors"
 
@@ -37,28 +50,11 @@ class Sponsor(Base):
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     name = Column(String)
     tezos_address = Column(String, unique=True)
-    sponsor_api_id = Column(
-        UUID(as_uuid=True),
-        ForeignKey("sponsor_apis.id"),
-        nullable=True
-    )
     withdraw_counter = Column(Integer, default=0)
-
+    api_id = Column(UUID(as_uuid=True), ForeignKey("sponsor_apis.id"))
     contracts = relationship("Contract", back_populates="owner")
     credits = relationship("Credit", back_populates="owner")
-
-
-class SponsorAPI(Base):
-    __tablename__ = "sponsor_apis"
-
-    def __repr__(self):
-        return "API(id='{}', name='{}', url='{}')".format(
-            self.id, self.name, self.url
-        )
-
-    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    url = Column(String, unique=True)
-    public_key = Column(String, nullable=False)
+    sponsor_api = relationship("SponsorAPI")
 
 
 # ------- CONTRACT ------- #

--- a/src/routes.py
+++ b/src/routes.py
@@ -58,9 +58,20 @@ async def create_contract(
 
 
 # PUT endpoints
+# FIXME: we obviously need to protect this in some way, but we'll rework
+# security in a later upgrade
+@router.put("/sponsor_api", response_model=bool)
+async def update_sponsor_api(
+    api_update: schemas.SponsorAPIUpdate,
+    db: Session = Depends(database.get_db)
+):
+    return crud.update_sponsor_api(db, api_update)
+
+
 @router.put("/entrypoints", response_model=list[schemas.Entrypoint])
 async def update_entrypoints(
-    entrypoints: list[schemas.EntrypointUpdate], db: Session = Depends(database.get_db)
+    entrypoints: list[schemas.EntrypointUpdate],
+    db: Session = Depends(database.get_db)
 ):
     return crud.update_entrypoints(db, entrypoints)
 

--- a/src/schemas.py
+++ b/src/schemas.py
@@ -4,12 +4,19 @@ from pydantic import BaseModel, UUID4
 from typing import List, Any, Optional
 
 
-# -- UTILITY TYPES --
+# Utility types
 class ConditionType(enum.Enum):
     # Max number of calls to a given entrypoint, for all sponsee
     MAX_CALLS_PER_ENTRYPOINT = "MAX_CALLS_PER_ENTRYPOINT"
     # Max number of calls per sponsee per contract
     MAX_CALLS_PER_SPONSEE = "MAX_CALLS_PER_SPONSEE"
+
+
+# Sonsor APIs
+class SponsorAPIUpdate(BaseModel):
+    sponsor_id: UUID4
+    api_url: str
+    public_key: str
 
 
 # Sponsors
@@ -21,17 +28,11 @@ class Sponsor(SponsorBase):
     id: UUID4
     name: str
     withdraw_counter: int
+    api_id: UUID4 | None = None
 
 
 class SponsorCreation(SponsorBase):
     name: str
-
-
-# Sonsor APIs
-class SponsorAPICreation(BaseModel):
-    sponsor_id: UUID4
-    api_url: str
-    public_key: str
 
 
 # Entrypoints

--- a/src/schemas.py
+++ b/src/schemas.py
@@ -12,19 +12,26 @@ class ConditionType(enum.Enum):
     MAX_CALLS_PER_SPONSEE = "MAX_CALLS_PER_SPONSEE"
 
 
-# Users
-class UserBase(BaseModel):
-    address: str
+# Sponsors
+class SponsorBase(BaseModel):
+    tezos_address: str
 
 
-class User(UserBase):
+class Sponsor(SponsorBase):
     id: UUID4
     name: str
     withdraw_counter: int
 
 
-class UserCreation(UserBase):
+class SponsorCreation(SponsorBase):
     name: str
+
+
+# Sonsor APIs
+class SponsorAPICreation(BaseModel):
+    sponsor_id: UUID4
+    api_url: str
+    public_key: str
 
 
 # Entrypoints

--- a/src/schemas.py
+++ b/src/schemas.py
@@ -12,6 +12,12 @@ class ConditionType(enum.Enum):
     MAX_CALLS_PER_SPONSEE = "MAX_CALLS_PER_SPONSEE"
 
 
+class Receipt(BaseModel):
+    """Receipts returned by the sponsor APIs"""
+    gas_station_action: str
+    signature: str
+
+
 # Sonsor APIs
 class SponsorAPIUpdate(BaseModel):
     sponsor_id: UUID4

--- a/src/tezos.py
+++ b/src/tezos.py
@@ -99,13 +99,14 @@ async def confirm_deposit(tx_hash, payer, amount: Union[int, str]):
         return False
 
 
-async def confirm_withdraw(tx_hash, db, user_id, withdraw):
-    """Ensure withdraw transaction is successful to update credits user. \n
-    Can raise an OperationNotFound exception if transaction is not found.
+async def confirm_withdraw(tx_hash, db, sponsor_id, withdraw):
+    """Ensures the withdraw transaction is successful and updates the sponsor's
+    credit. Raises an OperationNotFound exception if transaction is not found.
     """
     await find_transaction(tx_hash)
     credit_update = schemas.CreditUpdate(
-        id=withdraw.id, amount=-withdraw.amount, owner_id=user_id, operation_hash=""
+        id=withdraw.id, amount=-withdraw.amount, owner_id=sponsor_id,
+        operation_hash=""
     )
     crud.update_credits(db, credit_update)
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -4,7 +4,7 @@
 import enum
 
 
-class UserNotFound(Exception):
+class SponsorNotFound(Exception):
     pass
 
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,9 +1,3 @@
-# -- EXCEPTIONS --
-
-
-import enum
-
-
 class SponsorNotFound(Exception):
     pass
 


### PR DESCRIPTION
Lots of things need to be improved, but this is a working example of a validation done by a third-party. The exact protocol needs to be written somewhere (I'll probably write documentation next week), but right now we have this:

- assume we have a regular sponsor registered in the gas station, who deposited credits and registered a contract KT1;
- `examples/main` registers to the gas station API at startup with something like
```
GAS_STATION_URL=http://localhost:8000 uvicorn examples.main:app --port 8005
```
and associates its own URL and public key with the sponsor (and thus, with the contract KT1)
- when we send an operation to the gas station, it looks if it needs to get the validation from another API;
- the operation is sent to the 2nd API, which accepts it up to two times per user;
- When the 2nd API accepts the operation, it returns a signed receipt to the gas station which checks the signature and tells the gas station what to do: post the operation itself with the deposited credits, return the receipt to the user (if the 2nd API posts the operation itself directly) or return an error.

I used JWT and RSA encryption for the signature of the token. Comments? Suggestions?